### PR TITLE
fix pretty printing empty return statement

### DIFF
--- a/lox.lox
+++ b/lox.lox
@@ -1167,7 +1167,11 @@ class Return {
   }
 
   str() {
-    return "return " + this.value.str() + ";" + chr(10);
+    if (this.value != nil) {
+      return "return " + this.value.str() + ";" + chr(10);
+    } else {
+      return "return;" + chr(10);
+    }
   }
 
   resolve(resolver) {


### PR DESCRIPTION
When there is no expression after the return keyword, `value` will be `nil`.

With this change LoxLox can pretty-print itself now!