### PR TITLE
Fixed 'patch does not apply' by updating jlox_diff.patch

### DIFF
--- a/jlox_diff.patch
+++ b/jlox_diff.patch
@@ -1,10 +1,10 @@
 diff --git a/java/com/craftinginterpreters/lox/Interpreter.java b/java/com/craftinginterpreters/lox/Interpreter.java
-index da0bf05..b1b9eb0 100644
+index 823503f4..8c638059 100644
 --- a/java/com/craftinginterpreters/lox/Interpreter.java
 +++ b/java/com/craftinginterpreters/lox/Interpreter.java
-@@ -1,6 +1,10 @@
- //> Evaluating Expressions interpreter-class
+@@ -2,6 +2,10 @@
  package com.craftinginterpreters.lox;
+ //> Statements and State import-list
  
 +import java.io.IOException;
 +import java.io.InputStreamReader;
@@ -13,16 +13,17 @@ index da0bf05..b1b9eb0 100644
  //> Functions import-array-list
  import java.util.ArrayList;
  //< Functions import-array-list
-@@ -33,6 +37,8 @@ class Interpreter implements Expr.Visitor<Object>, Stmt.Visitor<Void> {
- //< Resolving and Binding locals-field
- //> Functions interpreter-constructor
+@@ -35,6 +39,9 @@ class Interpreter implements Expr.Visitor<Object>,
  
+ //< Statements and State environment-field
+ //> Functions interpreter-constructor
++
 +  private InputStreamReader getcStream = new InputStreamReader(System.in, StandardCharsets.UTF_8);
 +
    Interpreter() {
      globals.define("clock", new LoxCallable() {
        @Override
-@@ -47,6 +53,72 @@ class Interpreter implements Expr.Visitor<Object>, Stmt.Visitor<Void> {
+@@ -49,8 +56,74 @@ class Interpreter implements Expr.Visitor<Object>,
        @Override
        public String toString() { return "<native fn>"; }
      });
@@ -93,5 +94,8 @@ index da0bf05..b1b9eb0 100644
 +      public String toString() { return "<native fn>"; }
 +    });
    }
+-  
++
  //< Functions interpreter-constructor
  /* Evaluating Expressions interpret < Statements and State interpret
+   void interpret(Expr expression) { // [void]


### PR DESCRIPTION
Because of new commits made to [jlox](https://github.com/munificent/craftinginterpreters), the `jlox_diff.patch` does not apply. When following the instructions in the README you get the error: `patch does not apply`.
To fix this I merged the changes in the old `jlox_diff.patch` with the updates made to [jlox](https://github.com/munificent/craftinginterpreters) and created a new patch with that.
If you have any more questions, I will be glad to answer them.

And I think it would be best to use a [git submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules) for jlox. You could for example add https://github.com/benhoyt/craftinginterpreters as a `submodule`. This makes it much easier for users using this repository, because they don't need to clone  [jlox](https://github.com/munificent/craftinginterpreters) and patch it as well, they only need to clone this repository. It also makes it so a bug like this one can't happen again, because the `submodule` is pointing to a specific working version.
It will also make it easier to maintain, as you just need to change the `submodule` instead of also creating a new patch.