### PR TITLE
Fixed bug when class initializer contains inner function

### DIFF
--- a/lox.lox
+++ b/lox.lox
@@ -1383,6 +1383,7 @@ class Parser {
     this.functionDepth = 0;
     this.classDepth = 0;
     this.token = nil;
+    this.inInitializer = false;
     this.scanner = Scanner();
     this.next();
   }

--- a/lox.lox
+++ b/lox.lox
@@ -1608,10 +1608,11 @@ class Parser {
     this.consume(LEFT_BRACE, "Expect '{' before " + kind + " body.");
 
     this.functionDepth = this.functionDepth + 1;
+    var inInit = this.inInitializer;
     this.inInitializer = kind == "method" and name.value == "init";
     var body = this.block();
     this.functionDepth = this.functionDepth - 1;
-    this.inInitializer = false;
+    this.inInitializer = inInit;
 
     return Function(name.value, parameters, body);
   }


### PR DESCRIPTION
See the following
```
class A {
    init() {
        fun test {}
        return test;
    }
}
```
The error is not detected currently because the parser... forgets it is in an initializer when it goes into the function 'test'
This PR makes it remember so it correctly reports the error.